### PR TITLE
[BE] add: 감정 일기, 커뮤니티 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'

--- a/src/main/java/com/realthon/on/community/controller/BoardController.java
+++ b/src/main/java/com/realthon/on/community/controller/BoardController.java
@@ -1,0 +1,61 @@
+package com.realthon.on.community.controller;
+
+import com.realthon.on.community.dto.request.CommunityReqeustDto;
+import com.realthon.on.community.dto.response.CommunityResponseDto;
+import com.realthon.on.community.entity.HashTagType;
+import com.realthon.on.community.service.BoardService;
+import com.realthon.on.global.base.response.ResponseBody;
+import com.realthon.on.global.base.response.ResponseUtil;
+import com.realthon.on.security.oauth2.principal.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "BOARD API", description = "게시글 API")
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @Operation(summary = "게시글 생성", description = "새로운 게시글을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ResponseBody<CommunityResponseDto.BoardResponseDto>> createDiary(@RequestBody @Valid CommunityReqeustDto.AddBaordRequestDto requestDto) {
+        CommunityResponseDto.BoardResponseDto responseDto = boardService.createBoard(requestDto);
+
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "해시태그별 게시글 목록 조회", description = "특정 해시태그에 해당하는 게시글 목록을 조회합니다.")
+    @GetMapping("/hashtag/{hashtag}")
+    public ResponseEntity<ResponseBody<List<CommunityResponseDto.BoardResponseDto>>> getBoardsByHashtag(
+            @PathVariable HashTagType hashtag) {
+        List<CommunityResponseDto.BoardResponseDto> boards = boardService.getBoardsByHashTag(hashtag);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(boards));
+    }
+
+    @Operation(summary = "게시글 수정", description = "게시글 ID에 해당하는 게시글을 수정합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseBody<CommunityResponseDto.BoardResponseDto>> updateBoard(
+            @PathVariable Long id,
+            @RequestBody @Valid CommunityReqeustDto.UpdateBoardRequestDto requestDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        CommunityResponseDto.BoardResponseDto responseDto = boardService.updateBoard(id, requestDto,principalDetails.getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "게시글 삭제", description = "게시글 ID에 해당하는 게시글을 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseBody<String>> deleteBoard(@PathVariable Long id) {
+        boardService.deleteBoard(id);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("게시글이 성공적으로 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/realthon/on/community/controller/CommentController.java
+++ b/src/main/java/com/realthon/on/community/controller/CommentController.java
@@ -1,0 +1,59 @@
+package com.realthon.on.community.controller;
+
+import com.realthon.on.community.dto.request.CommunityReqeustDto;
+import com.realthon.on.community.dto.response.CommunityResponseDto;
+import com.realthon.on.community.service.CommentService;
+import com.realthon.on.global.base.response.ResponseBody;
+import com.realthon.on.global.base.response.ResponseUtil;
+import com.realthon.on.security.oauth2.principal.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "COMMENT API", description = "게시글 댓글 API")
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @Operation(summary = "댓글 생성", description = "새로운 댓글을 생성합니다.")
+    @PostMapping("/api/boards/{boardId}/comments")
+    public ResponseEntity<ResponseBody<CommunityResponseDto.CommentResponseDto>> createComment( @PathVariable Long boardId, @RequestBody @Valid CommunityReqeustDto.AddCommentRequestDto requestDto) {
+        CommunityResponseDto.CommentResponseDto responseDto = commentService.createComment(boardId,requestDto);
+
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "게시글별 댓글 목록 조회", description = "특정 게시글에 해당하는 댓글 목록을 조회합니다.")
+    @GetMapping("/api/boards/{boardId}/comments")
+    public ResponseEntity<ResponseBody<List<CommunityResponseDto.CommentResponseDto>>> getCommentsByBoard(
+            @PathVariable Long boardId) {
+        List<CommunityResponseDto.CommentResponseDto> boards = commentService.getCommentsByBoard(boardId);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(boards));
+    }
+
+    @Operation(summary = "댓글 수정", description = "댓글 ID에 해당하는 댓글을 수정합니다.")
+    @PutMapping("/api/comments/{id}")
+    public ResponseEntity<ResponseBody<CommunityResponseDto.CommentResponseDto>> updateComment(
+            @PathVariable Long id,
+            @RequestBody @Valid CommunityReqeustDto.UpdateCommentRequestDto requestDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        CommunityResponseDto.CommentResponseDto responseDto = commentService.updateComment(id, requestDto,principalDetails.getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글 ID에 해당하는 댓글을 삭제합니다.")
+    @DeleteMapping("/api/comments/{id}")
+    public ResponseEntity<ResponseBody<String>> deleteComment(@PathVariable Long id) {
+        commentService.deleteComment(id);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("댓글이 성공적으로 삭제되었습니다."));
+    }}

--- a/src/main/java/com/realthon/on/community/controller/LikeController.java
+++ b/src/main/java/com/realthon/on/community/controller/LikeController.java
@@ -1,0 +1,45 @@
+package com.realthon.on.community.controller;
+
+import com.realthon.on.community.service.LikeService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.realthon.on.community.dto.response.CommunityResponseDto;
+import com.realthon.on.global.base.response.ResponseBody;
+import com.realthon.on.global.base.response.ResponseUtil;
+import com.realthon.on.security.oauth2.principal.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "LIKE API", description = "게시글 좋아요 API")
+@RestController
+@RequestMapping("/api/boards/{boardId}/likes")
+@RequiredArgsConstructor
+public class LikeController {
+    private final LikeService likeService;
+
+    @Operation(summary = "좋아요 생성", description = "새로운 좋아요를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ResponseBody<String>> like(@PathVariable Long boardId,
+                                     @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        likeService.addLike(boardId, principalDetails.getUser().getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("좋아요가 성공적으로 등록되었습니다."));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ResponseBody<String>> unlike(@PathVariable Long boardId,
+                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        likeService.removeLike(boardId, principalDetails.getId());
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("좋아요가 성공적으로 취소되었습니다."));
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<ResponseBody<CommunityResponseDto.LikesCountResponseDto>> getLikesCount(@PathVariable Long boardId) {
+        long count = likeService.getLikesCountByBoard(boardId);
+        CommunityResponseDto.LikesCountResponseDto responseDto = new CommunityResponseDto.LikesCountResponseDto(boardId, count);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+}

--- a/src/main/java/com/realthon/on/community/controller/LikeController.java
+++ b/src/main/java/com/realthon/on/community/controller/LikeController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class LikeController {
     private final LikeService likeService;
 
-    @Operation(summary = "좋아요 생성", description = "새로운 좋아요를 생성합니다.")
+    @Operation(summary = "좋아요 등록", description = "새로운 좋아요를 등록합니다.")
     @PostMapping
     public ResponseEntity<ResponseBody<String>> like(@PathVariable Long boardId,
                                      @AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -29,6 +29,7 @@ public class LikeController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("좋아요가 성공적으로 등록되었습니다."));
     }
 
+    @Operation(summary = "좋아요 취소", description = "좋아요를 취소합니다.")
     @DeleteMapping
     public ResponseEntity<ResponseBody<String>> unlike(@PathVariable Long boardId,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -36,6 +37,7 @@ public class LikeController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse("좋아요가 성공적으로 취소되었습니다."));
     }
 
+    @Operation(summary = "좋아요 개수", description = "게시글별 좋아요 개수를 집계합니다")
     @GetMapping("/count")
     public ResponseEntity<ResponseBody<CommunityResponseDto.LikesCountResponseDto>> getLikesCount(@PathVariable Long boardId) {
         long count = likeService.getLikesCountByBoard(boardId);

--- a/src/main/java/com/realthon/on/community/dto/request/CommunityReqeustDto.java
+++ b/src/main/java/com/realthon/on/community/dto/request/CommunityReqeustDto.java
@@ -1,0 +1,62 @@
+package com.realthon.on.community.dto.request;
+
+import com.realthon.on.community.entity.HashTagType;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.util.Set;
+
+public class CommunityReqeustDto {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AddBaordRequestDto {
+        private Long userId;
+        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+        private String title;
+        private String content;
+        private Set<HashTagType> hashtags;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateBoardRequestDto {
+        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+        private String title;
+        private String content;
+        private Set<HashTagType> hashtags;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AddCommentRequestDto {
+        private Long userId;
+        @NotBlank(message = "내용은 반드시 입력해야 합니다.")
+        private String content;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateCommentRequestDto {
+        @NotBlank(message = "내용은 반드시 입력해야 합니다.")
+        private String content;
+    }
+
+
+
+
+
+
+}
+

--- a/src/main/java/com/realthon/on/community/dto/response/CommunityResponseDto.java
+++ b/src/main/java/com/realthon/on/community/dto/response/CommunityResponseDto.java
@@ -1,0 +1,69 @@
+package com.realthon.on.community.dto.response;
+
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.Comment;
+import com.realthon.on.community.entity.HashTagType;
+import com.realthon.on.community.entity.Like;
+import com.realthon.on.emotionDiary.dto.response.EmotionDiaryResponseDto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public class CommunityResponseDto {
+
+    @Getter
+    @Builder
+    public static class BoardResponseDto {
+        private Long boardId;
+        private String title;
+        private String content;
+        private Long userId;
+        private Set<HashTagType> hashtags;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+    }
+    public static BoardResponseDto fromBoardEntity(Board board) {
+        return BoardResponseDto.builder()
+                .boardId(board.getId())
+                .userId(board.getUser().getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .hashtags(board.getHashtags())
+                .createdAt(board.getCreatedAt())
+                .modifiedAt(board.getModifiedAt())
+                .build();
+}
+
+    @Getter
+    @Builder
+    public static class CommentResponseDto {
+        private Long commentId;
+        private String content;
+        private Long boardId;
+        private Long userId;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+    }
+
+    public static CommentResponseDto fromCommentEntity(Comment comment) {
+        return CommentResponseDto.builder()
+                .commentId(comment.getId())
+                .userId(comment.getUser().getId())
+                .boardId(comment.getBoard().getId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .modifiedAt(comment.getModifiedAt())
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class LikesCountResponseDto {
+        private Long boardId;
+        private Long count;
+    }
+
+}

--- a/src/main/java/com/realthon/on/community/entity/Board.java
+++ b/src/main/java/com/realthon/on/community/entity/Board.java
@@ -1,0 +1,52 @@
+package com.realthon.on.community.entity;
+
+import com.realthon.on.global.base.domain.BaseEntity;
+import com.realthon.on.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Board extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ElementCollection(fetch = FetchType.EAGER,targetClass = HashTagType.class)
+    @CollectionTable(name = "board_hashtags", joinColumns = @JoinColumn(name = "board_id"))
+    @Enumerated(EnumType.STRING)
+    private Set<HashTagType> hashtags = new HashSet<>();
+
+    @Builder
+    public Board(User user, String title, String content, Set<HashTagType> hashtags) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.hashtags = hashtags != null ? hashtags : new HashSet<>();
+    }
+
+    public void update(String title, String content,Set<HashTagType> hashtags) {
+        this.title = title;
+        this.content = content;
+        this.hashtags.clear();
+        if (hashtags != null) {
+            this.hashtags.addAll(hashtags);
+        }
+    }
+}

--- a/src/main/java/com/realthon/on/community/entity/Comment.java
+++ b/src/main/java/com/realthon/on/community/entity/Comment.java
@@ -1,39 +1,41 @@
-package com.realthon.on.emotionDiary.entity;
-
+package com.realthon.on.community.entity;
 import com.realthon.on.global.base.domain.BaseEntity;
 import com.realthon.on.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class EmotionDiary extends BaseEntity {
-
+public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    private String title;
-
     @Lob
+    @Column(nullable = false)
     private String content;
 
     @Builder
-    public EmotionDiary(User user, String title, String content) {
+    public Comment(User user, Board board,String title, String content) {
         this.user = user;
-        this.title = title;
+        this.board = board;
         this.content = content;
     }
 
-    public void update(String title, String content) {
-        this.title = title;
+    public void update(String content) {
         this.content = content;
     }
-
 }

--- a/src/main/java/com/realthon/on/community/entity/HashTagType.java
+++ b/src/main/java/com/realthon/on/community/entity/HashTagType.java
@@ -1,0 +1,9 @@
+package com.realthon.on.community.entity;
+
+public enum HashTagType {
+    NEOKDURI,  // 넋두리
+    JABDAM,    // 잡담
+    CHIYU      // 치유
+}
+
+

--- a/src/main/java/com/realthon/on/community/entity/Like.java
+++ b/src/main/java/com/realthon/on/community/entity/Like.java
@@ -1,0 +1,34 @@
+package com.realthon.on.community.entity;
+
+import com.realthon.on.global.base.domain.BaseEntity;
+import com.realthon.on.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "board_like",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"board_id", "user_id"})})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Like extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id", nullable = false)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Like(User user, Board board) {
+        this.user = user;
+        this.board = board;
+    }
+}

--- a/src/main/java/com/realthon/on/community/repository/BoardRepository.java
+++ b/src/main/java/com/realthon/on/community/repository/BoardRepository.java
@@ -1,0 +1,14 @@
+package com.realthon.on.community.repository;
+
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.HashTagType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    List<Board> findDistinctByHashtags(HashTagType hashtag);
+}
+

--- a/src/main/java/com/realthon/on/community/repository/CommentRepository.java
+++ b/src/main/java/com/realthon/on/community/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.realthon.on.community.repository;
+
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByBoard(Board board);
+
+}

--- a/src/main/java/com/realthon/on/community/repository/LikeRepository.java
+++ b/src/main/java/com/realthon/on/community/repository/LikeRepository.java
@@ -1,0 +1,18 @@
+package com.realthon.on.community.repository;
+
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.Like;
+import com.realthon.on.user.entity.User;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LikeRepository extends CrudRepository<Like, Long> {
+    boolean existsByBoardAndUser(Board board, User user);
+
+    Optional<Like> findByBoardAndUser(Board board, User user);
+
+    long countByBoard(Board board);
+}

--- a/src/main/java/com/realthon/on/community/service/BoardService.java
+++ b/src/main/java/com/realthon/on/community/service/BoardService.java
@@ -1,0 +1,73 @@
+package com.realthon.on.community.service;
+
+import com.realthon.on.community.dto.request.CommunityReqeustDto;
+import com.realthon.on.community.dto.response.CommunityResponseDto;
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.HashTagType;
+import com.realthon.on.community.repository.BoardRepository;
+import com.realthon.on.global.base.response.exception.BusinessException;
+import com.realthon.on.global.base.response.exception.ExceptionType;
+import com.realthon.on.user.entity.User;
+import com.realthon.on.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    //게시글 생성
+    @Transactional
+    public CommunityResponseDto.BoardResponseDto createBoard(CommunityReqeustDto.AddBaordRequestDto request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() ->  new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        Board board = Board.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .user(user)
+                .hashtags(request.getHashtags())
+                .build();
+
+        boardRepository.save(board);
+        return CommunityResponseDto.fromBoardEntity(board);
+    }
+
+    //해시태그별 게시글 목록 조회
+    public List<CommunityResponseDto.BoardResponseDto> getBoardsByHashTag(HashTagType hashtag) {
+        List<Board> boards = boardRepository.findDistinctByHashtags(hashtag);
+        return boards.stream()
+                .map(CommunityResponseDto::fromBoardEntity)
+                .collect(Collectors.toList());
+    }
+
+    //게시글 수정
+    @Transactional
+    public CommunityResponseDto.BoardResponseDto updateBoard(Long id, CommunityReqeustDto.UpdateBoardRequestDto requestDto, Long authenticatedUserId) {
+        Board board = boardRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+
+        if (!board.getUser().getId().equals(authenticatedUserId)) {
+            throw new BusinessException(ExceptionType.ACCESS_DENIED);
+        }
+
+        board.update(requestDto.getTitle(), requestDto.getContent(),requestDto.getHashtags());
+        return CommunityResponseDto.fromBoardEntity(board);
+    }
+
+    @Transactional
+    public void deleteBoard(Long id) {
+        if (!boardRepository.existsById(id)) {
+            throw new BusinessException(ExceptionType.BOARD_NOT_FOUND);
+        }
+        boardRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/realthon/on/community/service/CommentService.java
+++ b/src/main/java/com/realthon/on/community/service/CommentService.java
@@ -1,0 +1,78 @@
+package com.realthon.on.community.service;
+
+import com.realthon.on.community.dto.request.CommunityReqeustDto;
+import com.realthon.on.community.dto.response.CommunityResponseDto;
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.Comment;
+import com.realthon.on.community.repository.BoardRepository;
+import com.realthon.on.community.repository.CommentRepository;
+import com.realthon.on.global.base.response.exception.BusinessException;
+import com.realthon.on.global.base.response.exception.ExceptionType;
+import com.realthon.on.user.entity.User;
+import com.realthon.on.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    //댓글 생성
+    @Transactional
+    public CommunityResponseDto.CommentResponseDto createComment(Long boardId, CommunityReqeustDto.AddCommentRequestDto request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() ->  new BusinessException(ExceptionType.USER_NOT_FOUND));
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() ->  new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .user(user)
+                .board(board)
+                .build();
+
+        commentRepository.save(comment);
+        return CommunityResponseDto.fromCommentEntity(comment);
+    }
+
+    //게시글 별 댓글 목록 조회
+    public List<CommunityResponseDto.CommentResponseDto> getCommentsByBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+        List<Comment> comments = commentRepository.findAllByBoard(board);
+
+        return comments.stream()
+                .map(CommunityResponseDto::fromCommentEntity)
+                .collect(Collectors.toList());
+    }
+
+    //댓글 수정
+    @Transactional
+    public CommunityResponseDto.CommentResponseDto updateComment(Long id, CommunityReqeustDto.UpdateCommentRequestDto requestDto, Long authenticatedUserId) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.COMMENT_NOT_FOUND));
+
+        if (!comment.getUser().getId().equals(authenticatedUserId)) {
+            throw new BusinessException(ExceptionType.ACCESS_DENIED);
+        }
+
+        comment.update(requestDto.getContent());
+        return CommunityResponseDto.fromCommentEntity(comment);
+    }
+
+    //댓글 삭제
+    @Transactional
+    public void deleteComment(Long id) {
+        if (!commentRepository.existsById(id)) {
+            throw new BusinessException(ExceptionType.COMMENT_NOT_FOUND);
+        }
+        commentRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/realthon/on/community/service/LikeService.java
+++ b/src/main/java/com/realthon/on/community/service/LikeService.java
@@ -1,0 +1,65 @@
+package com.realthon.on.community.service;
+
+import com.realthon.on.community.entity.Board;
+import com.realthon.on.community.entity.Like;
+import com.realthon.on.community.repository.BoardRepository;
+import com.realthon.on.community.repository.LikeRepository;
+import com.realthon.on.global.base.response.exception.BusinessException;
+import com.realthon.on.global.base.response.exception.ExceptionType;
+import com.realthon.on.user.entity.User;
+import com.realthon.on.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    //좋아요 추가
+    public void addLike(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        boolean exists = likeRepository.existsByBoardAndUser(board, user);
+        if (exists) {
+            throw new BusinessException(ExceptionType.LIKE_ALREADY_EXISTS);
+        }
+
+        Like like = Like.builder()
+                .board(board)
+                .user(user)
+                .build();
+
+        likeRepository.save(like);
+    }
+
+    // 좋아요 취소
+    public void removeLike(Long boardId, Long userId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        Like like = likeRepository.findByBoardAndUser(board, user)
+                .orElseThrow(() -> new BusinessException(ExceptionType.LIKE_NOT_FOUND));
+
+        likeRepository.delete(like);
+    }
+
+    // 게시글 좋아요 개수 조회
+    @Transactional(readOnly = true)
+    public long getLikesCountByBoard(Long boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.BOARD_NOT_FOUND));
+        return likeRepository.countByBoard(board);
+    }
+}

--- a/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
+++ b/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "Diary API", description = "감정일기 CRUD API")
+@Tag(name = "Diary API", description = "감정일기 API")
 @RestController
 @RequestMapping("/api/diaries")
 @RequiredArgsConstructor
@@ -31,6 +31,7 @@ public class EmotionDiaryController {
 
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
+
     @Operation(summary = "특정 감정일기 조회", description = "ID를 통해 특정 감정일기를 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> getDiaryById(@PathVariable Long id) {
@@ -44,6 +45,7 @@ public class EmotionDiaryController {
             description = "쿼리 파라미터 userId를 전달하면 해당 사용자의 감정일기 목록을 조회하고, " +
                     "userId를 전달하지 않으면 전체 감정일기 목록을 조회합니다."
     )
+    @GetMapping
     public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getDiariesByUserId(@RequestParam(required = false) Long userId) {
         List<EmotionDiaryResponseDto> diaries;
         if (userId == null) {
@@ -57,7 +59,7 @@ public class EmotionDiaryController {
     @Operation(summary = "감정일기 수정", description = "ID를 통해 특정 감정일기를 수정합니다.")
     @PutMapping("/{id}")
     public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> updateDiary(@PathVariable Long id, @RequestBody @Valid EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto requestDto, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() ); //principalDetails.getId()
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() );
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
 

--- a/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
+++ b/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
@@ -1,0 +1,61 @@
+package com.realthon.on.emotionDiary.controller;
+
+import com.realthon.on.emotionDiary.dto.request.EmotionDiaryRequestDto;
+import com.realthon.on.emotionDiary.dto.response.EmotionDiaryResponseDto;
+import com.realthon.on.emotionDiary.service.EmotrionDiaryService;
+import com.realthon.on.global.base.response.ResponseBody;
+import com.realthon.on.global.base.response.ResponseUtil;
+import com.realthon.on.security.oauth2.principal.PrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Diary API", description = "감정일기 CRUD API")
+@RestController
+@RequestMapping("/api/diaries")
+@RequiredArgsConstructor
+public class EmotionDiaryController {
+
+    private final EmotrionDiaryService emotionDiaryService;
+
+    @Operation(summary = "감정일기 생성", description = "새로운 감정일기를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> createDiary(@RequestBody @Valid EmotionDiaryRequestDto.AddEmotionDiaryRequestDto requestDto) {
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.createDiary(requestDto);
+
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+    @Operation(summary = "특정 감정일기 조회", description = "ID를 통해 특정 감정일기를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> getDiaryById(@PathVariable Long id) {
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.getDiaryById(id);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "모든 감정일기 조회", description = "모든 감정일기 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getAllDiaries() {
+        List<EmotionDiaryResponseDto> responses = emotionDiaryService.getAllDiaries();
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responses));
+    }
+
+    @Operation(summary = "감정일기 수정", description = "ID를 통해 특정 감정일기를 수정합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> updateDiary(@PathVariable Long id, @RequestBody @Valid EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto requestDto, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() );
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
+    }
+
+    @Operation(summary = "감정일기 삭제", description = "ID를 통해 특정 감정일기를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseBody<String>> deleteDiary(@PathVariable Long id) {
+        emotionDiaryService.deleteDiary(id);
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse("일기가 성공적으로 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
+++ b/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
@@ -32,7 +32,7 @@ public class EmotionDiaryController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
 
-    @Operation(summary = "특정 감정일기 조회", description = "ID를 통해 특정 감정일기를 조회합니다.")
+    @Operation(summary = "특정 감정일기 조회", description = "diaryID를 통해 특정 감정일기를 조회합니다.")
     @GetMapping("/{id}")
     public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> getDiaryById(@PathVariable Long id) {
         EmotionDiaryResponseDto responseDto = emotionDiaryService.getDiaryById(id);
@@ -42,28 +42,22 @@ public class EmotionDiaryController {
 
     @Operation(
             summary = "감정일기 목록 조회",
-            description = "쿼리 파라미터 userId를 전달하면 해당 사용자의 감정일기 목록을 조회하고, " +
-                    "userId를 전달하지 않으면 전체 감정일기 목록을 조회합니다."
+            description = "쿼리 파라미터 userId를 전달하면 해당 사용자의 감정일기 목록을 조회합니다."
     )
     @GetMapping
-    public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getDiariesByUserId(@RequestParam(required = false) Long userId) {
-        List<EmotionDiaryResponseDto> diaries;
-        if (userId == null) {
-            diaries = emotionDiaryService.getAllDiaries();  // 전체 일기 조회
-        } else {
-            diaries = emotionDiaryService.getAllByUserId(userId);  // 특정 사용자 일기 조회
-        }
+    public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getDiariesByUserId(@RequestParam Long userId) {
+        List<EmotionDiaryResponseDto> diaries = emotionDiaryService.getAllByUserId(userId);
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(diaries));
     }
 
-    @Operation(summary = "감정일기 수정", description = "ID를 통해 특정 감정일기를 수정합니다.")
+    @Operation(summary = "감정일기 수정", description = "diaryID를 통해 특정 감정일기를 수정합니다.")
     @PutMapping("/{id}")
     public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> updateDiary(@PathVariable Long id, @RequestBody @Valid EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto requestDto, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() );
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto, principalDetails.getId() );
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
 
-    @Operation(summary = "감정일기 삭제", description = "ID를 통해 특정 감정일기를 삭제합니다.")
+    @Operation(summary = "감정일기 삭제", description = "diaryId를 통해 특정 감정일기를 삭제합니다.")
     @DeleteMapping("/{id}")
     public ResponseEntity<ResponseBody<String>> deleteDiary(@PathVariable Long id) {
         emotionDiaryService.deleteDiary(id);

--- a/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
+++ b/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
@@ -38,17 +38,26 @@ public class EmotionDiaryController {
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
 
-    @Operation(summary = "모든 감정일기 조회", description = "모든 감정일기 목록을 조회합니다.")
-    @GetMapping
-    public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getAllDiaries() {
-        List<EmotionDiaryResponseDto> responses = emotionDiaryService.getAllDiaries();
-        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responses));
+
+    @Operation(
+            summary = "감정일기 목록 조회",
+            description = "쿼리 파라미터 userId를 전달하면 해당 사용자의 감정일기 목록을 조회하고, " +
+                    "userId를 전달하지 않으면 전체 감정일기 목록을 조회합니다."
+    )
+    public ResponseEntity<ResponseBody<List<EmotionDiaryResponseDto>>> getDiariesByUserId(@RequestParam(required = false) Long userId) {
+        List<EmotionDiaryResponseDto> diaries;
+        if (userId == null) {
+            diaries = emotionDiaryService.getAllDiaries();  // 전체 일기 조회
+        } else {
+            diaries = emotionDiaryService.getAllByUserId(userId);  // 특정 사용자 일기 조회
+        }
+        return ResponseEntity.ok(ResponseUtil.createSuccessResponse(diaries));
     }
 
     @Operation(summary = "감정일기 수정", description = "ID를 통해 특정 감정일기를 수정합니다.")
     @PutMapping("/{id}")
     public ResponseEntity<ResponseBody<EmotionDiaryResponseDto>> updateDiary(@PathVariable Long id, @RequestBody @Valid EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto requestDto, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() );
+        EmotionDiaryResponseDto responseDto = emotionDiaryService.updateDiary(id, requestDto,principalDetails.getId() ); //principalDetails.getId()
         return ResponseEntity.ok(ResponseUtil.createSuccessResponse(responseDto));
     }
 

--- a/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
+++ b/src/main/java/com/realthon/on/emotionDiary/controller/EmotionDiaryController.java
@@ -41,7 +41,7 @@ public class EmotionDiaryController {
 
 
     @Operation(
-            summary = "감정일기 목록 조회",
+            summary = "유저별 감정일기 목록 조회",
             description = "쿼리 파라미터 userId를 전달하면 해당 사용자의 감정일기 목록을 조회합니다."
     )
     @GetMapping

--- a/src/main/java/com/realthon/on/emotionDiary/dto/request/EmotionDiaryRequestDto.java
+++ b/src/main/java/com/realthon/on/emotionDiary/dto/request/EmotionDiaryRequestDto.java
@@ -1,0 +1,30 @@
+package com.realthon.on.emotionDiary.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+
+public class EmotionDiaryRequestDto {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AddEmotionDiaryRequestDto {
+        private Long userId;
+        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+        private String title;
+        private String content;
+    }
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateEmotionDiaryRequestDto {
+        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
+        private String title;
+        private String content;
+    }
+}
+

--- a/src/main/java/com/realthon/on/emotionDiary/dto/request/EmotionDiaryRequestDto.java
+++ b/src/main/java/com/realthon/on/emotionDiary/dto/request/EmotionDiaryRequestDto.java
@@ -1,7 +1,12 @@
 package com.realthon.on.emotionDiary.dto.request;
 
+import com.realthon.on.emotionDiary.entity.WeatherType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Set;
 
 
 public class EmotionDiaryRequestDto {
@@ -12,8 +17,11 @@ public class EmotionDiaryRequestDto {
     @Builder
     public static class AddEmotionDiaryRequestDto {
         private Long userId;
-        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
-        private String title;
+        private LocalDate date;
+        private WeatherType weather;
+        private Set<String> hashtags;
+        @Size(max = 500, message = "내용은 500자 이내여야 합니다.")
+        @NotBlank(message = "내용은 반드시 입력해야 합니다.")
         private String content;
     }
     @Getter
@@ -22,8 +30,11 @@ public class EmotionDiaryRequestDto {
     @AllArgsConstructor
     @Builder
     public static class UpdateEmotionDiaryRequestDto {
-        @NotBlank(message = "제목은 반드시 입력해야 합니다.")
-        private String title;
+        private LocalDate date;
+        private WeatherType weather;
+        private Set<String> hashtags;
+        @Size(max = 500, message = "내용은 500자 이내여야 합니다.")
+        @NotBlank(message = "내용은 반드시 입력해야 합니다.")
         private String content;
     }
 }

--- a/src/main/java/com/realthon/on/emotionDiary/dto/response/EmotionDiaryResponseDto.java
+++ b/src/main/java/com/realthon/on/emotionDiary/dto/response/EmotionDiaryResponseDto.java
@@ -1,0 +1,26 @@
+package com.realthon.on.emotionDiary.dto.response;
+
+import com.realthon.on.emotionDiary.entity.EmotionDiary;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EmotionDiaryResponseDto {
+        private Long id;
+        private Long userId;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+        public static EmotionDiaryResponseDto fromEntity(EmotionDiary diary) {
+                return EmotionDiaryResponseDto.builder()
+                        .id(diary.getId())
+                        .userId(diary.getUser().getId())
+                        .title(diary.getTitle())
+                        .content(diary.getContent())
+                        .createdAt(diary.getCreatedAt())
+                        .modifiedAt(diary.getModifiedAt())
+                        .build();
+        }}

--- a/src/main/java/com/realthon/on/emotionDiary/dto/response/EmotionDiaryResponseDto.java
+++ b/src/main/java/com/realthon/on/emotionDiary/dto/response/EmotionDiaryResponseDto.java
@@ -1,15 +1,21 @@
 package com.realthon.on.emotionDiary.dto.response;
 
 import com.realthon.on.emotionDiary.entity.EmotionDiary;
+import com.realthon.on.emotionDiary.entity.WeatherType;
 import lombok.*;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Set;
 
 @Getter
 @Builder
 public class EmotionDiaryResponseDto {
         private Long id;
         private Long userId;
-        private String title;
+        private LocalDate date;
+        private WeatherType weather;
+        private Set<String> hashtags;
         private String content;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
@@ -18,7 +24,9 @@ public class EmotionDiaryResponseDto {
                 return EmotionDiaryResponseDto.builder()
                         .id(diary.getId())
                         .userId(diary.getUser().getId())
-                        .title(diary.getTitle())
+                        .date(diary.getDate())
+                        .weather(diary.getWeather())
+                        .hashtags(diary.getHashtags())
                         .content(diary.getContent())
                         .createdAt(diary.getCreatedAt())
                         .modifiedAt(diary.getModifiedAt())

--- a/src/main/java/com/realthon/on/emotionDiary/entity/EmotionDiary.java
+++ b/src/main/java/com/realthon/on/emotionDiary/entity/EmotionDiary.java
@@ -5,6 +5,10 @@ import com.realthon.on.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,21 +23,34 @@ public class EmotionDiary extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    private String title;
-
-    @Lob
+    @Column(length = 500)
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    private WeatherType weather;
+
+    private LocalDate date;
+
+    @ElementCollection
+    @CollectionTable(name = "diary_hashtag", joinColumns = @JoinColumn(name = "diary_id"))
+    @Column(name = "hashtag")
+    private Set<String> hashtags = new HashSet<>();
+
     @Builder
-    public EmotionDiary(User user, String title, String content) {
+    public EmotionDiary(User user, String content, LocalDate date, WeatherType weather, Set<String> hashtags) {
         this.user = user;
-        this.title = title;
+
         this.content = content;
+        this.date = date != null ? date : LocalDate.now();
+        this.weather = weather;
+        this.hashtags = hashtags;
     }
 
-    public void update(String title, String content) {
-        this.title = title;
+    public void update(LocalDate date, WeatherType weather, Set<String>hashtags, String content) {
         this.content = content;
+        this.weather = weather;
+        this.hashtags = hashtags;
+        this.date = date;
     }
 
 }

--- a/src/main/java/com/realthon/on/emotionDiary/entity/EmotionDiary.java
+++ b/src/main/java/com/realthon/on/emotionDiary/entity/EmotionDiary.java
@@ -1,0 +1,39 @@
+package com.realthon.on.emotionDiary.entity;
+
+import com.realthon.on.global.base.domain.BaseEntity;
+import com.realthon.on.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class EmotionDiary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    @Builder // 안전하고 가독성 높은 객체 생성을 위한 빌더
+    public EmotionDiary(User user, String title, String content) {
+        this.user = user;
+        this.title = title;
+        this.content = content;
+    }
+
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/realthon/on/emotionDiary/entity/WeatherType.java
+++ b/src/main/java/com/realthon/on/emotionDiary/entity/WeatherType.java
@@ -1,0 +1,5 @@
+package com.realthon.on.emotionDiary.entity;
+
+public enum WeatherType {
+    SUNNY, RAINY, CLOUDY, SNOWY, WINDY
+}

--- a/src/main/java/com/realthon/on/emotionDiary/repository/EmotionDiaryRepository.java
+++ b/src/main/java/com/realthon/on/emotionDiary/repository/EmotionDiaryRepository.java
@@ -4,7 +4,10 @@ import com.realthon.on.emotionDiary.entity.EmotionDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
+    List<EmotionDiary> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
 
 }

--- a/src/main/java/com/realthon/on/emotionDiary/repository/EmotionDiaryRepository.java
+++ b/src/main/java/com/realthon/on/emotionDiary/repository/EmotionDiaryRepository.java
@@ -1,0 +1,10 @@
+package com.realthon.on.emotionDiary.repository;
+
+import com.realthon.on.emotionDiary.entity.EmotionDiary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmotionDiaryRepository extends JpaRepository<EmotionDiary, Long> {
+
+}

--- a/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
+++ b/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
@@ -23,13 +23,15 @@ public class EmotrionDiaryService {
     private final UserRepository userRepository;
 
     //감정일기 생성
-    @Transactional // 쓰기 작업이므로 트랜잭션 설정
+    @Transactional
     public EmotionDiaryResponseDto createDiary(EmotionDiaryRequestDto.AddEmotionDiaryRequestDto request) {
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
         EmotionDiary diary = EmotionDiary.builder()
                 .user(user)
-                .title(request.getTitle())
+                .weather(request.getWeather())
+                .date(request.getDate())
+                .hashtags(request.getHashtags())
                 .content(request.getContent())
                 .build();
         EmotionDiary savedDiary = emotionDiaryRepository.save(diary);
@@ -50,14 +52,6 @@ public class EmotrionDiaryService {
                 .collect(Collectors.toList());
     }
 
-    // 모든 감정일기 조회
-    //추후 페이징 처리
-    public List<EmotionDiaryResponseDto> getAllDiaries() {
-        return emotionDiaryRepository.findAll().stream()
-                .map(EmotionDiaryResponseDto::fromEntity)
-                .collect(Collectors.toList());
-    }
-
     //감정일기 수정
     @Transactional
     public EmotionDiaryResponseDto updateDiary(Long id, EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto request,Long authenticatedUserId) {
@@ -68,7 +62,7 @@ public class EmotrionDiaryService {
             throw new BusinessException(ExceptionType.ACCESS_DENIED);
         }
 
-        diary.update(request.getTitle(), request.getContent()); // update 메서드에 감정 필드 추가
+        diary.update(request.getDate(), request.getWeather(),request.getHashtags(), request.getContent()); // update 메서드에 감정 필드 추가
         return EmotionDiaryResponseDto.fromEntity(diary);
     }
     //감정일기 삭제 (Delete)

--- a/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
+++ b/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
@@ -43,6 +43,13 @@ public class EmotrionDiaryService {
         return EmotionDiaryResponseDto.fromEntity(diary);
     }
 
+    public List<EmotionDiaryResponseDto> getAllByUserId(Long userId) {
+        return emotionDiaryRepository.findAllByUser_IdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(EmotionDiaryResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
     // 모든 감정일기 조회
     //추후 페이징 처리
     public List<EmotionDiaryResponseDto> getAllDiaries() {

--- a/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
+++ b/src/main/java/com/realthon/on/emotionDiary/service/EmotrionDiaryService.java
@@ -1,0 +1,72 @@
+package com.realthon.on.emotionDiary.service;
+
+import com.realthon.on.emotionDiary.dto.request.EmotionDiaryRequestDto;
+import com.realthon.on.emotionDiary.dto.response.EmotionDiaryResponseDto;
+import com.realthon.on.emotionDiary.entity.EmotionDiary;
+import com.realthon.on.emotionDiary.repository.EmotionDiaryRepository;
+import com.realthon.on.global.base.response.exception.BusinessException;
+import com.realthon.on.global.base.response.exception.ExceptionType;
+import com.realthon.on.user.entity.User;
+import com.realthon.on.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class EmotrionDiaryService {
+    private final EmotionDiaryRepository emotionDiaryRepository;
+    private final UserRepository userRepository;
+
+    //감정일기 생성
+    @Transactional // 쓰기 작업이므로 트랜잭션 설정
+    public EmotionDiaryResponseDto createDiary(EmotionDiaryRequestDto.AddEmotionDiaryRequestDto request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+        EmotionDiary diary = EmotionDiary.builder()
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+        EmotionDiary savedDiary = emotionDiaryRepository.save(diary);
+        return EmotionDiaryResponseDto.fromEntity(savedDiary);
+    }
+
+    //특정 감정일기 조회
+    public EmotionDiaryResponseDto getDiaryById(Long id) {
+        EmotionDiary diary = emotionDiaryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.DIARY_NOT_FOUND));
+        return EmotionDiaryResponseDto.fromEntity(diary);
+    }
+
+    // 모든 감정일기 조회
+    //추후 페이징 처리
+    public List<EmotionDiaryResponseDto> getAllDiaries() {
+        return emotionDiaryRepository.findAll().stream()
+                .map(EmotionDiaryResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    //감정일기 수정
+    @Transactional
+    public EmotionDiaryResponseDto updateDiary(Long id, EmotionDiaryRequestDto.UpdateEmotionDiaryRequestDto request,Long authenticatedUserId) {
+        EmotionDiary diary = emotionDiaryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.DIARY_NOT_FOUND));
+
+        if (!diary.getUser().getId().equals(authenticatedUserId)) {
+            throw new BusinessException(ExceptionType.ACCESS_DENIED);
+        }
+
+        diary.update(request.getTitle(), request.getContent()); // update 메서드에 감정 필드 추가
+        return EmotionDiaryResponseDto.fromEntity(diary);
+    }
+    //감정일기 삭제 (Delete)
+    @Transactional // 쓰기 작업이므로 트랜잭션 설정
+    public void deleteDiary(Long id) {
+        emotionDiaryRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/realthon/on/global/base/response/exception/ExceptionType.java
+++ b/src/main/java/com/realthon/on/global/base/response/exception/ExceptionType.java
@@ -39,7 +39,13 @@ public enum ExceptionType {
     STORE_NOT_FOUND(NOT_FOUND, "S001", "존재하지 않는 가게"),
 
     //diary
-    DIARY_NOT_FOUND(NOT_FOUND, "D001", "존재하지 않는 일기")
+    DIARY_NOT_FOUND(NOT_FOUND, "D001", "존재하지 않는 일기"),
+
+    //board
+    BOARD_NOT_FOUND(NOT_FOUND, "B001", "존재하지 않는 게시글"),
+    COMMENT_NOT_FOUND(NOT_FOUND, "B002", "존재하지 않는 댓글"),
+    LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "B003", "이미 좋아요가 존재합니다."),
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "B004", "좋아요가 존재하지 않습니다.");
     ;
 
 

--- a/src/main/java/com/realthon/on/global/base/response/exception/ExceptionType.java
+++ b/src/main/java/com/realthon/on/global/base/response/exception/ExceptionType.java
@@ -31,12 +31,15 @@ public enum ExceptionType {
     ALREADY_REGISTERED_USER(NOT_ACCEPTABLE , "U006","이미 최종 회원 가입된 사용자"),
     NOT_REGISTERED_USER(FORBIDDEN , "U007","최종 회원 가입 되지 않은 사용자"),
     UNAUTHORIZED_USER(UNAUTHORIZED, "U005","로그인 되지 않은 사용자"),
+    ACCESS_DENIED(FORBIDDEN, "U008", "권한이 없습니다."),
 
 
 
     //store
-    STORE_NOT_FOUND(NOT_FOUND, "S001", "존재하지 않는 가게")
+    STORE_NOT_FOUND(NOT_FOUND, "S001", "존재하지 않는 가게"),
 
+    //diary
+    DIARY_NOT_FOUND(NOT_FOUND, "D001", "존재하지 않는 일기")
     ;
 
 

--- a/src/main/java/com/realthon/on/security/oauth2/principal/PrincipalDetails.java
+++ b/src/main/java/com/realthon/on/security/oauth2/principal/PrincipalDetails.java
@@ -34,7 +34,9 @@ public class PrincipalDetails implements OAuth2User, UserDetails {
         this.user = user;
         this.attributes = attributes;
     }
-
+    public Long getId() {
+        return user.getId();
+    }
 
     @Override
     public String getName() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,13 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/oauth-test?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/oauth-test?useSSL=false&characterEncoding=UTF-8&serverTimezone=UTC&allowPublicKeyRetrieval=true
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: true
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## ✨ PR 세부 내용
이번 PR에서는 감정일기 및 커뮤니티 관련 API를 전반적으로 구현했습니다.

[감정 일기 관련]
감정 일기 생성
특정 감정 일기 조회
유저별 감정 일기 목록 조회
감정 일기 수정
감정 일기 삭제

[게시글 관련]
게시글 생성
해시태그별 게시글 목록 조회
게시글 수정
게시글 삭제

[댓글 관련]
댓글 생성
게시글별 댓글 목록 조회
댓글 수정
댓글 삭제

[좋아요 관련]
좋아요 등록
좋아요 취소
게시글별 좋아요 개수 집계




